### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,3 @@
+language = "nodejs"
+  run = "npm run test"
+  

--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # node_storage_manager
+[![Run on Repl.it](https://repl.it/badge/github/9trocode/node_storage_manager)](https://repl.it/github/9trocode/node_storage_manager)
 Storage Manager for cross platform e.g AWS S3 GStorage and file-system


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).